### PR TITLE
Fixes to `syft_datasets`

### DIFF
--- a/packages/syft-datasets/notebooks/example_usage.ipynb
+++ b/packages/syft-datasets/notebooks/example_usage.ipynb
@@ -105,7 +105,7 @@
    "outputs": [],
    "source": [
     "# Getting a dataset by name\n",
-    "my_dataset = syd.get(name=\"my-dataset\")\n",
+    "my_dataset = syd.get(name=\"my-dataset-2\")\n",
     "my_dataset.describe()"
    ]
   },
@@ -139,9 +139,31 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "9",
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "syd.delete(name=\"my-dataset-2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "syd.get_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
@@ -161,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/packages/syft-datasets/src/syft_datasets/__init__.py
+++ b/packages/syft-datasets/src/syft_datasets/__init__.py
@@ -50,3 +50,12 @@ def get_all(
         order_by,
         sort_order,
     )
+
+
+def delete(
+    name: str,
+    datasite: str | None = None,
+    syftbox_config_path: PathLike | None = None,
+) -> None:
+    dataset_manager = SyftDatasetManager.load(config_path=syftbox_config_path)
+    return dataset_manager.delete(name=name, datasite=datasite)

--- a/packages/syft-datasets/src/syft_datasets/dataset.py
+++ b/packages/syft-datasets/src/syft_datasets/dataset.py
@@ -152,7 +152,10 @@ class Dataset(DatasetBase, PydanticFormatterMixin):
 
         # TODO add 'private' to sb workspace
         private_datasets_dir = (
-            self.syftbox_client.workspace.data_dir / "private" / "syft_datasets"
+            self.syftbox_client.workspace.data_dir
+            / "private"
+            / self.syftbox_client.email
+            / "syft_datasets"
         )
 
         return private_datasets_dir / self.name


### PR DESCRIPTION
- add client's email to before private `syft_datasets` to allow for local testing between different clients
<img width="424" alt="Screenshot 2025-07-07 at 14 57 40" src="https://github.com/user-attachments/assets/6cfd78c9-0a0b-4dd5-b619-221c5b32a89d" />

- add `syd.delete` functionality